### PR TITLE
v1.1.0: watcher hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,14 @@ The function returns a promise that resolves to an array of [Stats](#stats-type)
 
 ### watch(options: RunnerOptions): Promise\<Stats[]\>
 
-This function is similar to run, but it also watches for changes in the input directory and automatically recompiles the translation files. It uses the same `RunnerOptions` object as the run function.
+This function is similar to run, but it also watches for changes in the input directory and automatically recompiles the translation files.
 
-> Note that you can use the `--watch` flag when running the command-line interface to achieve the same result.
+Receive the options `WatcherOptions` object with the same properties as the `RunnerOptions` object but with the following additional properties:
+
+- `hooks.beforeRun` [optional] - A function that will be called before running the pipeline.
+- `hooks.afterRun` [optional] - A function that will be called after running the pipeline.
+
+> Note that you can use the `--watch` flag when running the command-line interface.
 
 ### Types
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "i18n-collector",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "i18n-collector",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-collector",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A tool for bundling localization files",
   "main": "./lib/index.js",
   "module": "./lib/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-collector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A tool for bundling localization files",
   "main": "./lib/index.js",
   "module": "./lib/index.esm.js",
@@ -35,12 +35,12 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "eslint . --fix",
-      "prettier --write .",
+      "eslint --fix",
+      "prettier --write",
       "npm run test"
     ],
     "*.md": [
-      "prettier --write ."
+      "prettier --write"
     ]
   },
   "files": [

--- a/test/watch.spec.ts
+++ b/test/watch.spec.ts
@@ -1,0 +1,209 @@
+import { watch } from "../src";
+import { vol } from "memfs";
+jest.mock("fs/promises");
+import fs from "fs";
+import type { WatcherOptions } from "../src/watch";
+describe("watch.ts", () => {
+  jest.spyOn(fs, "watch").mockImplementation(() => {
+    return void 0 as any;
+  });
+
+  afterEach(() => {
+    vol.reset();
+  });
+
+  describe("watch()", () => {
+    test("Should call beforeRun hook", async () => {
+      vol.fromNestedJSON(
+        {
+          src: {
+            module1: {
+              "model_1.locale.json": JSON.stringify({
+                uk: {
+                  key1: "value1",
+                },
+                en: {
+                  key2: "value2",
+                },
+              }),
+            },
+          },
+        },
+        "/home"
+      );
+
+      const beforeRun = jest.fn();
+
+      const options: WatcherOptions = {
+        inputPath: "/home/src",
+        outputPath: "/home/dist",
+        merge: true,
+        clear: true,
+        hooks: {
+          beforeRun,
+        },
+      };
+
+      await watch(options);
+
+      expect(beforeRun).toHaveBeenCalledTimes(1);
+
+      expect(vol.toJSON()).toEqual({
+        "/home/dist/uk.json": '{"model_1":{"key1":"value1"}}',
+        "/home/dist/en.json": '{"model_1":{"key2":"value2"}}',
+        "/home/src/module1/model_1.locale.json":
+          '{"uk":{"key1":"value1"},"en":{"key2":"value2"}}',
+      });
+    });
+
+    test("Should call afterRun hook", async () => {
+      vol.fromNestedJSON(
+        {
+          src: {
+            module1: {
+              "model_1.locale.json": JSON.stringify({
+                uk: {
+                  key1: "value1",
+                },
+                en: {
+                  key2: "value2",
+                },
+              }),
+            },
+          },
+        },
+        "/home"
+      );
+
+      const afterRun = jest.fn();
+
+      const options: WatcherOptions = {
+        inputPath: "/home/src",
+        outputPath: "/home/dist",
+        merge: true,
+        clear: true,
+        hooks: {
+          afterRun,
+        },
+      };
+
+      await watch(options);
+
+      expect(afterRun).toHaveBeenCalledTimes(1);
+
+      expect(afterRun).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            filePath: "/home/dist/uk.json",
+          }),
+          expect.objectContaining({
+            filePath: "/home/dist/en.json",
+          }),
+        ])
+      );
+
+      expect(vol.toJSON()).toEqual({
+        "/home/dist/uk.json": '{"model_1":{"key1":"value1"}}',
+        "/home/dist/en.json": '{"model_1":{"key2":"value2"}}',
+        "/home/src/module1/model_1.locale.json":
+          '{"uk":{"key1":"value1"},"en":{"key2":"value2"}}',
+      });
+    });
+
+    test("Should scan, compile and write locales files", async () => {
+      vol.fromNestedJSON(
+        {
+          dont_compile_these_files: {
+            "other.locale.json": JSON.stringify({
+              en: {
+                key: "value",
+              },
+            }),
+          },
+          some_other_directory: {
+            "image.png": "image_content",
+          },
+          src: {
+            module1: {
+              "model_1.locale.json": JSON.stringify({
+                uk: {
+                  key1: "value1",
+                },
+                en: {
+                  key2: "value2",
+                },
+              }),
+            },
+            some_directory: {
+              "some-component.locale.json": JSON.stringify({
+                uk: {
+                  key3: "value3",
+                },
+                en: {
+                  key4: "value4",
+                },
+              }),
+            },
+
+            module2: {
+              "some-module.locale.json": JSON.stringify({
+                en: {
+                  key5: "value5",
+                },
+              }),
+            },
+
+            module3: {
+              "some-module-2.locale.json": JSON.stringify({
+                gr: {
+                  key6: "value7",
+                },
+              }),
+            },
+
+            module4: {
+              "uk.locale.json": "",
+            },
+          },
+          dist: {
+            "uk.locale.json": JSON.stringify({
+              module1: {
+                old: "data",
+              },
+            }),
+            some_other_file_but_should_be_delete: "some_other_content",
+          },
+        },
+        "/home"
+      );
+
+      const options: WatcherOptions = {
+        inputPath: "/home/src",
+        outputPath: "/home/dist",
+        merge: true,
+        clear: true,
+      };
+
+      await watch(options);
+
+      expect(vol.toJSON()).toEqual({
+        "/home/dont_compile_these_files/other.locale.json":
+          '{"en":{"key":"value"}}',
+        "/home/some_other_directory/image.png": "image_content",
+        "/home/src/module1/model_1.locale.json":
+          '{"uk":{"key1":"value1"},"en":{"key2":"value2"}}',
+        "/home/src/some_directory/some-component.locale.json":
+          '{"uk":{"key3":"value3"},"en":{"key4":"value4"}}',
+        "/home/src/module2/some-module.locale.json": '{"en":{"key5":"value5"}}',
+        "/home/src/module3/some-module-2.locale.json":
+          '{"gr":{"key6":"value7"}}',
+        "/home/src/module4/uk.locale.json": "",
+        "/home/dist/uk.json":
+          '{"model_1":{"key1":"value1"},"some-component":{"key3":"value3"}}',
+        "/home/dist/en.json":
+          '{"model_1":{"key2":"value2"},"some-module":{"key5":"value5"},"some-component":{"key4":"value4"}}',
+        "/home/dist/gr.json": '{"some-module-2":{"key6":"value7"}}',
+      });
+    });
+  });
+});


### PR DESCRIPTION
What's new:
- Added `hooks` in `watch` API, allowing to perform actions before and after the pipeline process.

Read more about it in the `watch()` section of the [README](https://github.com/gmaxlev/i18n-collector#watchoptions-runneroptions-promisestats).